### PR TITLE
Properly cast ansible_distribution_version as int

### DIFF
--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -16,7 +16,7 @@
 
 - name: Overrides start condition for procps
   copy: src=procps.override dest=/etc/init/procps.override
-  when: ansible_distribution_version < 18
+  when: ansible_distribution_version|int < 18
 
 - name: Sets module parameters at boot
   template:


### PR DESCRIPTION
Without this, you can get this (on Ansible `2.8.0`)
```
The conditional check 'ansible_distribution_version < 18' failed. The error was: Unexpected templating type error occurred on ({% if ansible_distribution_version < 18 %} True {% else %} False {% endif %}): '<' not supported between instances of 'AnsibleUnsafeText' and 'int'
```